### PR TITLE
Fix tool support with local LLM

### DIFF
--- a/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
@@ -71,7 +71,7 @@ describe('<HistoryItemDisplay />', () => {
     const { lastFrame } = render(
       <HistoryItemDisplay {...baseItem} item={item} />,
     );
-    expect(lastFrame()).toContain('About Gemini CLI');
+    expect(lastFrame()).toContain('About Gemma CLI');
   });
 
   it('renders SessionSummaryDisplay for "quit" type', () => {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -10,8 +10,8 @@ import {
   Chat,
   EmbedContentResponse,
   GenerateContentResponse,
-  GoogleGenAI,
 } from '@google/genai';
+import { OpenAICompatibleContentGenerator } from './openAICompatibleContentGenerator.js';
 import { GeminiClient } from './client.js';
 import { AuthType, ContentGenerator } from './contentGenerator.js';
 import { GeminiChat } from './geminiChat.js';
@@ -28,7 +28,7 @@ const mockGenerateContentFn = vi.fn();
 const mockEmbedContentFn = vi.fn();
 const mockTurnRunFn = vi.fn();
 
-vi.mock('@google/genai');
+vi.mock('./openAICompatibleContentGenerator.js');
 vi.mock('./turn', () => {
   // Define a mock class that has the same shape as the real Turn
   class MockTurn {
@@ -72,19 +72,16 @@ describe('Gemini Client (client.ts)', () => {
     // Disable 429 simulation for tests
     setSimulate429(false);
 
-    // Set up the mock for GoogleGenAI constructor and its methods
-    const MockedGoogleGenAI = vi.mocked(GoogleGenAI);
-    MockedGoogleGenAI.mockImplementation(() => {
-      const mock = {
-        chats: { create: mockChatCreateFn },
-        models: {
+    const MockedGenerator = vi.mocked(OpenAICompatibleContentGenerator);
+    MockedGenerator.mockImplementation(
+      () =>
+        ({
           generateContent: mockGenerateContentFn,
+          generateContentStream: vi.fn(),
+          countTokens: vi.fn(),
           embedContent: mockEmbedContentFn,
-        },
-      };
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return mock as any;
-    });
+        }) as unknown as OpenAICompatibleContentGenerator,
+    );
 
     mockChatCreateFn.mockResolvedValue({} as Chat);
     mockGenerateContentFn.mockResolvedValue({
@@ -135,7 +132,7 @@ describe('Gemini Client (client.ts)', () => {
     });
 
     // We can instantiate the client here since Config is mocked
-    // and the constructor will use the mocked GoogleGenAI
+    // and the constructor will use the mocked OpenAICompatibleContentGenerator
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const mockConfig = new Config({} as any);
     client = new GeminiClient(mockConfig);

--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -6,45 +6,21 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { createContentGenerator, AuthType } from './contentGenerator.js';
-import { createCodeAssistContentGenerator } from '../code_assist/codeAssist.js';
-import { GoogleGenAI } from '@google/genai';
+import { OpenAICompatibleContentGenerator } from './openAICompatibleContentGenerator.js';
 
-vi.mock('../code_assist/codeAssist.js');
-vi.mock('@google/genai');
+vi.mock('./openAICompatibleContentGenerator.js');
 
 describe('contentGenerator', () => {
-  it('should create a CodeAssistContentGenerator', async () => {
-    const mockGenerator = {} as unknown;
-    vi.mocked(createCodeAssistContentGenerator).mockResolvedValue(
-      mockGenerator as never,
+  it('should create an OpenAICompatibleContentGenerator', async () => {
+    const mockGenerator = {} as unknown as OpenAICompatibleContentGenerator;
+    vi.mocked(OpenAICompatibleContentGenerator).mockImplementation(
+      () => mockGenerator,
     );
     const generator = await createContentGenerator({
       model: 'test-model',
-      authType: AuthType.LOGIN_WITH_GOOGLE_PERSONAL,
+      authType: AuthType.USE_LOCAL_LLM,
     });
-    expect(createCodeAssistContentGenerator).toHaveBeenCalled();
+    expect(OpenAICompatibleContentGenerator).toHaveBeenCalled();
     expect(generator).toBe(mockGenerator);
-  });
-
-  it('should create a GoogleGenAI content generator', async () => {
-    const mockGenerator = {
-      models: {},
-    } as unknown;
-    vi.mocked(GoogleGenAI).mockImplementation(() => mockGenerator as never);
-    const generator = await createContentGenerator({
-      model: 'test-model',
-      apiKey: 'test-api-key',
-      authType: AuthType.USE_GEMINI,
-    });
-    expect(GoogleGenAI).toHaveBeenCalledWith({
-      apiKey: 'test-api-key',
-      vertexai: undefined,
-      httpOptions: {
-        headers: {
-          'User-Agent': expect.any(String),
-        },
-      },
-    });
-    expect(generator).toBe((mockGenerator as GoogleGenAI).models);
   });
 });

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -106,7 +106,7 @@ export async function createContentGeneratorConfig(
 }
 
 export async function createContentGenerator(
-  config: ContentGeneratorConfig,
+  _config: ContentGeneratorConfig,
 ): Promise<ContentGenerator> {
   // Always use local LLM (Ollama)
   return new OpenAICompatibleContentGenerator({

--- a/packages/core/src/core/openAICompatibleContentGenerator.ts
+++ b/packages/core/src/core/openAICompatibleContentGenerator.ts
@@ -15,6 +15,9 @@ import {
   Part,
   FinishReason,
   ContentListUnion,
+  FunctionCall,
+  Candidate,
+  GenerateContentResponseUsageMetadata,
 } from '@google/genai';
 import { ContentGenerator } from './contentGenerator.js';
 
@@ -26,11 +29,17 @@ export interface OpenAIConfig {
 
 // Create a custom response class that matches the expected interface
 class OpenAIGenerateContentResponse {
-  candidates: any[];
-  usageMetadata?: any;
+  candidates: Candidate[];
+  private _functionCalls: FunctionCall[] | undefined;
+  usageMetadata?: GenerateContentResponseUsageMetadata;
 
-  constructor(candidates: any[], usageMetadata?: any) {
+  constructor(
+    candidates: Candidate[],
+    functionCalls?: FunctionCall[],
+    usageMetadata?: GenerateContentResponseUsageMetadata,
+  ) {
     this.candidates = candidates;
+    this._functionCalls = functionCalls;
     this.usageMetadata = usageMetadata;
   }
 
@@ -40,8 +49,8 @@ class OpenAIGenerateContentResponse {
       return '';
     }
     return parts
-      .map((part: any) => part.text)
-      .filter((text: any) => typeof text === 'string')
+      .map((part: Part & { text?: string }) => part.text ?? '')
+      .filter((text: string) => text.length > 0)
       .join('');
   }
 
@@ -49,8 +58,8 @@ class OpenAIGenerateContentResponse {
     return '';
   }
 
-  get functionCalls(): any[] {
-    return [];
+  get functionCalls(): FunctionCall[] {
+    return this._functionCalls ?? [];
   }
 
   get executableCode(): string {
@@ -65,40 +74,44 @@ class OpenAIGenerateContentResponse {
 export class OpenAICompatibleContentGenerator implements ContentGenerator {
   constructor(private config: OpenAIConfig) {}
 
-  private convertToOpenAIMessages(contents: ContentListUnion): any[] {
+  private convertToOpenAIMessages(
+    contents: ContentListUnion,
+  ): Array<Record<string, unknown>> {
     // Handle string input
     if (typeof contents === 'string') {
       return [{ role: 'user', content: contents }];
     }
-    
+
     // Handle single Content object
     if (!Array.isArray(contents)) {
       const content = contents as Content;
       const role = content.role === 'model' ? 'assistant' : content.role;
       const parts = content.parts || [];
-      
+
       const textParts = parts
         .filter((part: Part) => 'text' in part)
-        .map((part: Part) => (part as any).text)
+        .map((part: Part & { text?: string }) => part.text ?? '')
         .join('\n');
-      
-      return [{
-        role,
-        content: textParts,
-      }];
+
+      return [
+        {
+          role,
+          content: textParts,
+        },
+      ];
     }
-    
+
     // Handle array of Content objects
-    return contents.map((content: any) => {
+    return contents.map((content: Content) => {
       const role = content.role === 'model' ? 'assistant' : content.role;
       const parts = content.parts || [];
-      
+
       // Combine all text parts into a single message
       const textParts = parts
         .filter((part: Part) => 'text' in part)
-        .map((part: Part) => (part as any).text)
+        .map((part: Part & { text?: string }) => part.text ?? '')
         .join('\n');
-      
+
       return {
         role,
         content: textParts,
@@ -106,50 +119,108 @@ export class OpenAICompatibleContentGenerator implements ContentGenerator {
     });
   }
 
-  private convertFromOpenAIResponse(openAIResponse: any): GenerateContentResponse {
-    const choice = openAIResponse.choices?.[0];
+  private convertFromOpenAIResponse(
+    openAIResponse: unknown,
+  ): GenerateContentResponse {
+    const choice = (
+      openAIResponse as {
+        choices?: Array<{
+          message?: {
+            content?: string;
+            tool_calls?: Array<{
+              id: string;
+              function: { name: string; arguments?: string };
+            }>;
+          };
+          finish_reason?: string;
+        }>;
+      }
+    ).choices?.[0];
     const messageContent = choice?.message?.content || '';
-    
+    const toolCalls = choice?.message?.tool_calls as
+      | Array<{ id: string; function: { name: string; arguments?: string } }>
+      | undefined;
+
     if (!choice) {
-      return new OpenAIGenerateContentResponse([]) as any;
+      return new OpenAIGenerateContentResponse([]);
     }
 
+    const parts: Part[] = [];
+    if (messageContent) {
+      parts.push({ text: messageContent });
+    }
+    let functionCalls: FunctionCall[] | undefined;
+    if (toolCalls && toolCalls.length > 0) {
+      functionCalls = toolCalls.map((tc) => ({
+        id: tc.id,
+        name: tc.function.name,
+        args: tc.function.arguments
+          ? (JSON.parse(tc.function.arguments) as Record<string, unknown>)
+          : {},
+        isClientInitiated: false,
+      }));
+      for (const fc of functionCalls) {
+        parts.push({ functionCall: fc });
+      }
+    }
     const content: Content = {
       role: 'model',
-      parts: [{ text: messageContent }],
+      parts,
     };
 
-    const candidates = [{
-      content,
-      index: 0,
-      finishReason: choice.finish_reason === 'stop' ? FinishReason.STOP : FinishReason.OTHER,
-    }];
+    const candidates = [
+      {
+        content,
+        index: 0,
+        finishReason:
+          choice.finish_reason === 'stop'
+            ? FinishReason.STOP
+            : FinishReason.OTHER,
+      },
+    ];
 
-    const usageMetadata = openAIResponse.usage ? {
-      promptTokenCount: openAIResponse.usage.prompt_tokens,
-      candidatesTokenCount: openAIResponse.usage.completion_tokens,
-      totalTokenCount: openAIResponse.usage.total_tokens,
-    } : undefined;
+    const usage = (
+      openAIResponse as {
+        usage?: {
+          prompt_tokens?: number;
+          completion_tokens?: number;
+          total_tokens?: number;
+        };
+      }
+    ).usage;
+    const usageMetadata = usage
+      ? {
+          promptTokenCount: usage.prompt_tokens,
+          candidatesTokenCount: usage.completion_tokens,
+          totalTokenCount: usage.total_tokens,
+        }
+      : undefined;
 
-    return new OpenAIGenerateContentResponse(candidates, usageMetadata) as any;
+    return new OpenAIGenerateContentResponse(
+      candidates,
+      functionCalls,
+      usageMetadata,
+    );
   }
 
   async generateContent(
     request: GenerateContentParameters,
   ): Promise<GenerateContentResponse> {
     const messages = this.convertToOpenAIMessages(request.contents);
-    
+
     // Add system instruction if provided
     if (request.config?.systemInstruction) {
       messages.unshift({
         role: 'system',
-        content: typeof request.config.systemInstruction === 'string' 
-          ? request.config.systemInstruction 
-          : (request.config.systemInstruction as any).text || '',
+        content:
+          typeof request.config.systemInstruction === 'string'
+            ? request.config.systemInstruction
+            : (request.config.systemInstruction as { text?: string }).text ||
+              '',
       });
     }
 
-    const openAIRequest = {
+    const openAIRequest: Record<string, unknown> = {
       model: this.config.model,
       messages,
       temperature: request.config?.temperature,
@@ -158,18 +229,40 @@ export class OpenAICompatibleContentGenerator implements ContentGenerator {
       stream: false,
     };
 
+    if (request.config?.tools && request.config.tools.length > 0) {
+      const tools = request.config.tools.flatMap((t) =>
+        'functionDeclarations' in t && Array.isArray(t.functionDeclarations)
+          ? t.functionDeclarations
+          : [],
+      );
+      if (tools.length > 0) {
+        openAIRequest['tools'] = tools.map((fd) => ({
+          type: 'function',
+          function: {
+            name: fd.name,
+            description: fd.description,
+            parameters: fd.parameters,
+          },
+        }));
+      }
+    }
+
     try {
       const response = await fetch(`${this.config.endpoint}/chat/completions`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          ...(this.config.apiKey && { 'Authorization': `Bearer ${this.config.apiKey}` }),
+          ...(this.config.apiKey && {
+            Authorization: `Bearer ${this.config.apiKey}`,
+          }),
         },
         body: JSON.stringify(openAIRequest),
       });
 
       if (!response.ok) {
-        throw new Error(`OpenAI API error: ${response.status} ${response.statusText}`);
+        throw new Error(
+          `OpenAI API error: ${response.status} ${response.statusText}`,
+        );
       }
 
       const openAIResponse = await response.json();
@@ -190,19 +283,25 @@ export class OpenAICompatibleContentGenerator implements ContentGenerator {
   private async *_generateContentStream(
     request: GenerateContentParameters,
   ): AsyncGenerator<GenerateContentResponse> {
+    if (request.config?.tools && request.config.tools.length > 0) {
+      yield await this.generateContent(request);
+      return;
+    }
     const messages = this.convertToOpenAIMessages(request.contents);
-    
+
     // Add system instruction if provided
     if (request.config?.systemInstruction) {
       messages.unshift({
         role: 'system',
-        content: typeof request.config.systemInstruction === 'string' 
-          ? request.config.systemInstruction 
-          : (request.config.systemInstruction as any).text || '',
+        content:
+          typeof request.config.systemInstruction === 'string'
+            ? request.config.systemInstruction
+            : (request.config.systemInstruction as { text?: string }).text ||
+              '',
       });
     }
 
-    const openAIRequest = {
+    const openAIRequest: Record<string, unknown> = {
       model: this.config.model,
       messages,
       temperature: request.config?.temperature,
@@ -216,13 +315,17 @@ export class OpenAICompatibleContentGenerator implements ContentGenerator {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          ...(this.config.apiKey && { 'Authorization': `Bearer ${this.config.apiKey}` }),
+          ...(this.config.apiKey && {
+            Authorization: `Bearer ${this.config.apiKey}`,
+          }),
         },
         body: JSON.stringify(openAIRequest),
       });
 
       if (!response.ok) {
-        throw new Error(`OpenAI API error: ${response.status} ${response.statusText}`);
+        throw new Error(
+          `OpenAI API error: ${response.status} ${response.statusText}`,
+        );
       }
 
       const reader = response.body?.getReader();
@@ -239,7 +342,7 @@ export class OpenAICompatibleContentGenerator implements ContentGenerator {
 
         buffer += decoder.decode(value, { stream: true });
         const lines = buffer.split('\n');
-        
+
         // Keep the last line if it's incomplete
         buffer = lines.pop() || '';
 
@@ -247,25 +350,28 @@ export class OpenAICompatibleContentGenerator implements ContentGenerator {
           if (line.startsWith('data: ')) {
             const data = line.slice(6);
             if (data === '[DONE]') continue;
-            
+
             try {
               const chunk = JSON.parse(data);
               const delta = chunk.choices?.[0]?.delta;
-              
+
               if (delta?.content) {
                 const finishReason = chunk.choices?.[0]?.finish_reason;
-                const candidates = [{
-                  content: {
-                    role: 'model',
-                    parts: [{ text: delta.content }],
+                const candidates = [
+                  {
+                    content: {
+                      role: 'model',
+                      parts: [{ text: delta.content }],
+                    },
+                    index: 0,
+                    finishReason:
+                      finishReason === 'stop' ? FinishReason.STOP : undefined,
                   },
-                  index: 0,
-                  finishReason: finishReason === 'stop' ? FinishReason.STOP : undefined,
-                }];
-                
-                yield new OpenAIGenerateContentResponse(candidates) as any;
+                ];
+
+                yield new OpenAIGenerateContentResponse(candidates);
               }
-            } catch (e) {
+            } catch {
               // Ignore parse errors for individual chunks
             }
           }
@@ -277,7 +383,9 @@ export class OpenAICompatibleContentGenerator implements ContentGenerator {
     }
   }
 
-  async countTokens(request: CountTokensParameters): Promise<CountTokensResponse> {
+  async countTokens(
+    request: CountTokensParameters,
+  ): Promise<CountTokensResponse> {
     // Simple approximation - you might want to use a proper tokenizer
     let text = '';
     if (typeof request.contents === 'string') {
@@ -286,32 +394,34 @@ export class OpenAICompatibleContentGenerator implements ContentGenerator {
       text = request.contents
         .flatMap((content: Content) => content.parts || [])
         .filter((part: Part) => 'text' in part)
-        .map((part: Part) => (part as any).text)
+        .map((part: Part & { text?: string }) => part.text ?? '')
         .join(' ');
     } else {
       // Single Content object
       const content = request.contents as Content;
-      text = content.parts
-        ?.filter((part: Part) => 'text' in part)
-        .map((part: Part) => (part as any).text)
-        .join(' ') || '';
+      text =
+        content.parts
+          ?.filter((part: Part) => 'text' in part)
+          .map((part: Part & { text?: string }) => part.text ?? '')
+          .join(' ') || '';
     }
-    
+
     // Rough approximation: 1 token ≈ 4 characters
     const tokenCount = Math.ceil(text.length / 4);
-    
+
     return {
       totalTokens: tokenCount,
     };
   }
 
-  async embedContent(request: EmbedContentParameters): Promise<EmbedContentResponse> {
-    // For now, return a dummy embedding
-    // You would implement actual embedding API call here if needed
+  async embedContent(
+    request: EmbedContentParameters,
+  ): Promise<EmbedContentResponse> {
+    const count = Array.isArray(request.contents) ? request.contents.length : 1;
     return {
-      embeddings: [{
+      embeddings: Array.from({ length: count }, () => ({
         values: new Array(768).fill(0),
-      }],
+      })),
     };
   }
 }


### PR DESCRIPTION
## Summary
- support tool calls when using the OpenAI compatible generator
- return dummy embeddings for all input texts
- update createContentGenerator() and corresponding tests
- adjust HistoryItemDisplay test expectation

## Testing
- `npm run lint:ci`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_b_68709be2b9bc832b982a9c51a2203981