### PR TITLE
Fix tool support with local LLM

### DIFF
--- a/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
@@ -71,7 +71,7 @@ describe('<HistoryItemDisplay />', () => {
     const { lastFrame } = render(
       <HistoryItemDisplay {...baseItem} item={item} />,
     );
-    expect(lastFrame()).toContain('About Gemini CLI');
+    expect(lastFrame()).toContain('About Gemma CLI');
   });
 
   it('renders SessionSummaryDisplay for "quit" type', () => {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -10,8 +10,8 @@ import {
   Chat,
   EmbedContentResponse,
   GenerateContentResponse,
-  GoogleGenAI,
 } from '@google/genai';
+import { OpenAICompatibleContentGenerator } from './openAICompatibleContentGenerator.js';
 import { GeminiClient } from './client.js';
 import { AuthType, ContentGenerator } from './contentGenerator.js';
 import { GeminiChat } from './geminiChat.js';
@@ -28,7 +28,7 @@ const mockGenerateContentFn = vi.fn();
 const mockEmbedContentFn = vi.fn();
 const mockTurnRunFn = vi.fn();
 
-vi.mock('@google/genai');
+vi.mock('./openAICompatibleContentGenerator.js');
 vi.mock('./turn', () => {
   // Define a mock class that has the same shape as the real Turn
   class MockTurn {
@@ -72,19 +72,16 @@ describe('Gemini Client (client.ts)', () => {
     // Disable 429 simulation for tests
     setSimulate429(false);
 
-    // Set up the mock for GoogleGenAI constructor and its methods
-    const MockedGoogleGenAI = vi.mocked(GoogleGenAI);
-    MockedGoogleGenAI.mockImplementation(() => {
-      const mock = {
-        chats: { create: mockChatCreateFn },
-        models: {
+    const MockedGenerator = vi.mocked(OpenAICompatibleContentGenerator);
+    MockedGenerator.mockImplementation(
+      () =>
+        ({
           generateContent: mockGenerateContentFn,
+          generateContentStream: vi.fn(),
+          countTokens: vi.fn(),
           embedContent: mockEmbedContentFn,
-        },
-      };
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return mock as any;
-    });
+        }) as unknown as OpenAICompatibleContentGenerator,
+    );
 
     mockChatCreateFn.mockResolvedValue({} as Chat);
     mockGenerateContentFn.mockResolvedValue({
@@ -135,7 +132,7 @@ describe('Gemini Client (client.ts)', () => {
     });
 
     // We can instantiate the client here since Config is mocked
-    // and the constructor will use the mocked GoogleGenAI
+    // and the constructor will use the mocked OpenAICompatibleContentGenerator
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const mockConfig = new Config({} as any);
     client = new GeminiClient(mockConfig);

--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -6,45 +6,21 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { createContentGenerator, AuthType } from './contentGenerator.js';
-import { createCodeAssistContentGenerator } from '../code_assist/codeAssist.js';
-import { GoogleGenAI } from '@google/genai';
+import { OpenAICompatibleContentGenerator } from './openAICompatibleContentGenerator.js';
 
-vi.mock('../code_assist/codeAssist.js');
-vi.mock('@google/genai');
+vi.mock('./openAICompatibleContentGenerator.js');
 
 describe('contentGenerator', () => {
-  it('should create a CodeAssistContentGenerator', async () => {
-    const mockGenerator = {} as unknown;
-    vi.mocked(createCodeAssistContentGenerator).mockResolvedValue(
-      mockGenerator as never,
+  it('should create an OpenAICompatibleContentGenerator', async () => {
+    const mockGenerator = {} as unknown as OpenAICompatibleContentGenerator;
+    vi.mocked(OpenAICompatibleContentGenerator).mockImplementation(
+      () => mockGenerator,
     );
     const generator = await createContentGenerator({
       model: 'test-model',
-      authType: AuthType.LOGIN_WITH_GOOGLE_PERSONAL,
+      authType: AuthType.USE_LOCAL_LLM,
     });
-    expect(createCodeAssistContentGenerator).toHaveBeenCalled();
+    expect(OpenAICompatibleContentGenerator).toHaveBeenCalled();
     expect(generator).toBe(mockGenerator);
-  });
-
-  it('should create a GoogleGenAI content generator', async () => {
-    const mockGenerator = {
-      models: {},
-    } as unknown;
-    vi.mocked(GoogleGenAI).mockImplementation(() => mockGenerator as never);
-    const generator = await createContentGenerator({
-      model: 'test-model',
-      apiKey: 'test-api-key',
-      authType: AuthType.USE_GEMINI,
-    });
-    expect(GoogleGenAI).toHaveBeenCalledWith({
-      apiKey: 'test-api-key',
-      vertexai: undefined,
-      httpOptions: {
-        headers: {
-          'User-Agent': expect.any(String),
-        },
-      },
-    });
-    expect(generator).toBe((mockGenerator as GoogleGenAI).models);
   });
 });

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -106,7 +106,7 @@ export async function createContentGeneratorConfig(
 }
 
 export async function createContentGenerator(
-  config: ContentGeneratorConfig,
+  _config: ContentGeneratorConfig,
 ): Promise<ContentGenerator> {
   // Always use local LLM (Ollama)
   return new OpenAICompatibleContentGenerator({

--- a/packages/core/src/core/openAICompatibleContentGenerator.test.ts
+++ b/packages/core/src/core/openAICompatibleContentGenerator.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { OpenAICompatibleContentGenerator } from './openAICompatibleContentGenerator.js';
+import type { Content, Part } from '@google/genai';
+
+const endpoint = 'http://localhost';
+const model = 'test-model';
+
+describe('OpenAICompatibleContentGenerator', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('converts functionResponse parts to tool messages', async () => {
+    const generator = new OpenAICompatibleContentGenerator({ endpoint, model });
+
+    const content: Content = {
+      role: 'tool',
+      parts: [
+        {
+          functionResponse: {
+            id: 'call1',
+            name: 'toolTest',
+            response: { content: [{ text: 'done' }] },
+          },
+        } as Part,
+      ],
+    };
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi
+        .fn()
+        .mockResolvedValue({ choices: [{ message: { content: 'ok' } }] }),
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    globalThis.fetch = fetchMock as any;
+
+    await generator.generateContent({ model, contents: [content] });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.messages[0]).toEqual({
+      role: 'tool',
+      content: 'done',
+      tool_call_id: 'call1',
+    });
+  });
+});

--- a/packages/core/src/core/openAICompatibleContentGenerator.ts
+++ b/packages/core/src/core/openAICompatibleContentGenerator.ts
@@ -77,16 +77,37 @@ export class OpenAICompatibleContentGenerator implements ContentGenerator {
   private convertToOpenAIMessages(
     contents: ContentListUnion,
   ): Array<Record<string, unknown>> {
-    // Handle string input
-    if (typeof contents === 'string') {
-      return [{ role: 'user', content: contents }];
-    }
-
-    // Handle single Content object
-    if (!Array.isArray(contents)) {
-      const content = contents as Content;
+    const convertSingle = (
+      content: Content,
+    ): Array<Record<string, unknown>> => {
       const role = content.role === 'model' ? 'assistant' : content.role;
       const parts = content.parts || [];
+
+      // Handle function response parts -> tool messages
+      if (role === 'tool') {
+        const fr = parts.find((p) => 'functionResponse' in p)?.functionResponse;
+        if (fr) {
+          let text = '';
+          const responseContent = fr.response?.content;
+          if (Array.isArray(responseContent)) {
+            text = responseContent
+              .filter((p: Part) => 'text' in p)
+              .map((p: Part & { text?: string }) => p.text ?? '')
+              .join('\n');
+          } else if (typeof responseContent === 'string') {
+            text = responseContent;
+          } else if (responseContent !== undefined) {
+            text = JSON.stringify(responseContent);
+          }
+          return [
+            {
+              role: 'tool',
+              content: text,
+              tool_call_id: fr.id,
+            },
+          ];
+        }
+      }
 
       const textParts = parts
         .filter((part: Part) => 'text' in part)
@@ -99,24 +120,18 @@ export class OpenAICompatibleContentGenerator implements ContentGenerator {
           content: textParts,
         },
       ];
+    };
+
+    // Handle string input
+    if (typeof contents === 'string') {
+      return [{ role: 'user', content: contents }];
     }
 
-    // Handle array of Content objects
-    return contents.map((content: Content) => {
-      const role = content.role === 'model' ? 'assistant' : content.role;
-      const parts = content.parts || [];
+    if (!Array.isArray(contents)) {
+      return convertSingle(contents as Content);
+    }
 
-      // Combine all text parts into a single message
-      const textParts = parts
-        .filter((part: Part) => 'text' in part)
-        .map((part: Part & { text?: string }) => part.text ?? '')
-        .join('\n');
-
-      return {
-        role,
-        content: textParts,
-      };
-    });
+    return contents.flatMap((c) => convertSingle(c as Content));
   }
 
   private convertFromOpenAIResponse(
@@ -254,6 +269,7 @@ export class OpenAICompatibleContentGenerator implements ContentGenerator {
             parameters: fd.parameters,
           },
         }));
+        openAIRequest['tool_choice'] = 'auto';
       }
     }
 
@@ -270,9 +286,17 @@ export class OpenAICompatibleContentGenerator implements ContentGenerator {
       });
 
       if (!response.ok) {
-        throw new Error(
-          `OpenAI API error: ${response.status} ${response.statusText}`,
-        );
+        const bodyText = await response.text();
+        let msg = `OpenAI API error: ${response.status} ${response.statusText}`;
+        if (bodyText) {
+          try {
+            const err = JSON.parse(bodyText);
+            msg += ` - ${err.error?.message ?? bodyText}`;
+          } catch {
+            msg += ` - ${bodyText}`;
+          }
+        }
+        throw new Error(msg);
       }
 
       const openAIResponse = await response.json();
@@ -333,9 +357,17 @@ export class OpenAICompatibleContentGenerator implements ContentGenerator {
       });
 
       if (!response.ok) {
-        throw new Error(
-          `OpenAI API error: ${response.status} ${response.statusText}`,
-        );
+        const bodyText = await response.text();
+        let msg = `OpenAI API error: ${response.status} ${response.statusText}`;
+        if (bodyText) {
+          try {
+            const err = JSON.parse(bodyText);
+            msg += ` - ${err.error?.message ?? bodyText}`;
+          } catch {
+            msg += ` - ${bodyText}`;
+          }
+        }
+        throw new Error(msg);
       }
 
       const reader = response.body?.getReader();
@@ -403,17 +435,43 @@ export class OpenAICompatibleContentGenerator implements ContentGenerator {
     } else if (Array.isArray(request.contents)) {
       text = request.contents
         .flatMap((content: Content) => content.parts || [])
-        .filter((part: Part) => 'text' in part)
-        .map((part: Part & { text?: string }) => part.text ?? '')
+        .map((part: Part) => {
+          if ('text' in part)
+            return (part as Part & { text?: string }).text ?? '';
+          if ('functionResponse' in part) {
+            const rc = part.functionResponse?.response?.content;
+            if (Array.isArray(rc)) {
+              return rc
+                .filter((p: Part) => 'text' in p)
+                .map((p: Part & { text?: string }) => p.text ?? '')
+                .join(' ');
+            }
+            if (typeof rc === 'string') return rc;
+            if (rc !== undefined) return JSON.stringify(rc);
+          }
+          return '';
+        })
         .join(' ');
     } else {
-      // Single Content object
       const content = request.contents as Content;
-      text =
-        content.parts
-          ?.filter((part: Part) => 'text' in part)
-          .map((part: Part & { text?: string }) => part.text ?? '')
-          .join(' ') || '';
+      text = (content.parts || [])
+        .map((part: Part) => {
+          if ('text' in part)
+            return (part as Part & { text?: string }).text ?? '';
+          if ('functionResponse' in part) {
+            const rc = part.functionResponse?.response?.content;
+            if (Array.isArray(rc)) {
+              return rc
+                .filter((p: Part) => 'text' in p)
+                .map((p: Part & { text?: string }) => p.text ?? '')
+                .join(' ');
+            }
+            if (typeof rc === 'string') return rc;
+            if (rc !== undefined) return JSON.stringify(rc);
+          }
+          return '';
+        })
+        .join(' ');
     }
 
     // Rough approximation: 1 token ≈ 4 characters

--- a/packages/core/src/core/openAICompatibleContentGenerator.ts
+++ b/packages/core/src/core/openAICompatibleContentGenerator.ts
@@ -15,6 +15,9 @@ import {
   Part,
   FinishReason,
   ContentListUnion,
+  FunctionCall,
+  Candidate,
+  GenerateContentResponseUsageMetadata,
 } from '@google/genai';
 import { ContentGenerator } from './contentGenerator.js';
 
@@ -26,11 +29,17 @@ export interface OpenAIConfig {
 
 // Create a custom response class that matches the expected interface
 class OpenAIGenerateContentResponse {
-  candidates: any[];
-  usageMetadata?: any;
+  candidates: Candidate[];
+  private _functionCalls: FunctionCall[] | undefined;
+  usageMetadata?: GenerateContentResponseUsageMetadata;
 
-  constructor(candidates: any[], usageMetadata?: any) {
+  constructor(
+    candidates: Candidate[],
+    functionCalls?: FunctionCall[],
+    usageMetadata?: GenerateContentResponseUsageMetadata,
+  ) {
     this.candidates = candidates;
+    this._functionCalls = functionCalls;
     this.usageMetadata = usageMetadata;
   }
 
@@ -40,8 +49,8 @@ class OpenAIGenerateContentResponse {
       return '';
     }
     return parts
-      .map((part: any) => part.text)
-      .filter((text: any) => typeof text === 'string')
+      .map((part: Part & { text?: string }) => part.text ?? '')
+      .filter((text: string) => text.length > 0)
       .join('');
   }
 
@@ -49,8 +58,8 @@ class OpenAIGenerateContentResponse {
     return '';
   }
 
-  get functionCalls(): any[] {
-    return [];
+  get functionCalls(): FunctionCall[] {
+    return this._functionCalls ?? [];
   }
 
   get executableCode(): string {
@@ -65,40 +74,44 @@ class OpenAIGenerateContentResponse {
 export class OpenAICompatibleContentGenerator implements ContentGenerator {
   constructor(private config: OpenAIConfig) {}
 
-  private convertToOpenAIMessages(contents: ContentListUnion): any[] {
+  private convertToOpenAIMessages(
+    contents: ContentListUnion,
+  ): Array<Record<string, unknown>> {
     // Handle string input
     if (typeof contents === 'string') {
       return [{ role: 'user', content: contents }];
     }
-    
+
     // Handle single Content object
     if (!Array.isArray(contents)) {
       const content = contents as Content;
       const role = content.role === 'model' ? 'assistant' : content.role;
       const parts = content.parts || [];
-      
+
       const textParts = parts
         .filter((part: Part) => 'text' in part)
-        .map((part: Part) => (part as any).text)
+        .map((part: Part & { text?: string }) => part.text ?? '')
         .join('\n');
-      
-      return [{
-        role,
-        content: textParts,
-      }];
+
+      return [
+        {
+          role,
+          content: textParts,
+        },
+      ];
     }
-    
+
     // Handle array of Content objects
-    return contents.map((content: any) => {
+    return contents.map((content: Content) => {
       const role = content.role === 'model' ? 'assistant' : content.role;
       const parts = content.parts || [];
-      
+
       // Combine all text parts into a single message
       const textParts = parts
         .filter((part: Part) => 'text' in part)
-        .map((part: Part) => (part as any).text)
+        .map((part: Part & { text?: string }) => part.text ?? '')
         .join('\n');
-      
+
       return {
         role,
         content: textParts,
@@ -106,50 +119,118 @@ export class OpenAICompatibleContentGenerator implements ContentGenerator {
     });
   }
 
-  private convertFromOpenAIResponse(openAIResponse: any): GenerateContentResponse {
-    const choice = openAIResponse.choices?.[0];
+  private convertFromOpenAIResponse(
+    openAIResponse: unknown,
+  ): GenerateContentResponse {
+    const choice = (
+      openAIResponse as {
+        choices?: Array<{
+          message?: {
+            content?: string;
+            tool_calls?: Array<{
+              id: string;
+              function: { name: string; arguments?: string };
+            }>;
+          };
+          finish_reason?: string;
+        }>;
+      }
+    ).choices?.[0];
     const messageContent = choice?.message?.content || '';
-    
+    const toolCalls = choice?.message?.tool_calls as
+      | Array<{ id: string; function: { name: string; arguments?: string } }>
+      | undefined;
+
     if (!choice) {
-      return new OpenAIGenerateContentResponse([]) as any;
+      return new OpenAIGenerateContentResponse([]);
     }
 
+    const parts: Part[] = [];
+    if (messageContent) {
+      parts.push({ text: messageContent });
+    }
+    let functionCalls: FunctionCall[] | undefined;
+    if (toolCalls && toolCalls.length > 0) {
+      functionCalls = toolCalls.map((tc) => {
+        let argsObj: Record<string, unknown> = {};
+        if (tc.function.arguments) {
+          try {
+            argsObj = JSON.parse(tc.function.arguments);
+          } catch {
+            console.warn(
+              `Failed to parse function arguments for ${tc.function.name}`,
+            );
+          }
+        }
+        return {
+          id: tc.id,
+          name: tc.function.name,
+          args: argsObj,
+          isClientInitiated: false,
+        };
+      });
+      for (const fc of functionCalls) {
+        parts.push({ functionCall: fc });
+      }
+    }
     const content: Content = {
       role: 'model',
-      parts: [{ text: messageContent }],
+      parts,
     };
 
-    const candidates = [{
-      content,
-      index: 0,
-      finishReason: choice.finish_reason === 'stop' ? FinishReason.STOP : FinishReason.OTHER,
-    }];
+    const candidates = [
+      {
+        content,
+        index: 0,
+        finishReason:
+          choice.finish_reason === 'stop'
+            ? FinishReason.STOP
+            : FinishReason.OTHER,
+      },
+    ];
 
-    const usageMetadata = openAIResponse.usage ? {
-      promptTokenCount: openAIResponse.usage.prompt_tokens,
-      candidatesTokenCount: openAIResponse.usage.completion_tokens,
-      totalTokenCount: openAIResponse.usage.total_tokens,
-    } : undefined;
+    const usage = (
+      openAIResponse as {
+        usage?: {
+          prompt_tokens?: number;
+          completion_tokens?: number;
+          total_tokens?: number;
+        };
+      }
+    ).usage;
+    const usageMetadata = usage
+      ? {
+          promptTokenCount: usage.prompt_tokens,
+          candidatesTokenCount: usage.completion_tokens,
+          totalTokenCount: usage.total_tokens,
+        }
+      : undefined;
 
-    return new OpenAIGenerateContentResponse(candidates, usageMetadata) as any;
+    return new OpenAIGenerateContentResponse(
+      candidates,
+      functionCalls,
+      usageMetadata,
+    );
   }
 
   async generateContent(
     request: GenerateContentParameters,
   ): Promise<GenerateContentResponse> {
     const messages = this.convertToOpenAIMessages(request.contents);
-    
+
     // Add system instruction if provided
     if (request.config?.systemInstruction) {
       messages.unshift({
         role: 'system',
-        content: typeof request.config.systemInstruction === 'string' 
-          ? request.config.systemInstruction 
-          : (request.config.systemInstruction as any).text || '',
+        content:
+          typeof request.config.systemInstruction === 'string'
+            ? request.config.systemInstruction
+            : (request.config.systemInstruction as { text?: string }).text ||
+              '',
       });
     }
 
-    const openAIRequest = {
+    const openAIRequest: Record<string, unknown> = {
       model: this.config.model,
       messages,
       temperature: request.config?.temperature,
@@ -158,18 +239,40 @@ export class OpenAICompatibleContentGenerator implements ContentGenerator {
       stream: false,
     };
 
+    if (request.config?.tools && request.config.tools.length > 0) {
+      const tools = request.config.tools.flatMap((t) =>
+        'functionDeclarations' in t && Array.isArray(t.functionDeclarations)
+          ? t.functionDeclarations
+          : [],
+      );
+      if (tools.length > 0) {
+        openAIRequest['tools'] = tools.map((fd) => ({
+          type: 'function',
+          function: {
+            name: fd.name,
+            description: fd.description,
+            parameters: fd.parameters,
+          },
+        }));
+      }
+    }
+
     try {
       const response = await fetch(`${this.config.endpoint}/chat/completions`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          ...(this.config.apiKey && { 'Authorization': `Bearer ${this.config.apiKey}` }),
+          ...(this.config.apiKey && {
+            Authorization: `Bearer ${this.config.apiKey}`,
+          }),
         },
         body: JSON.stringify(openAIRequest),
       });
 
       if (!response.ok) {
-        throw new Error(`OpenAI API error: ${response.status} ${response.statusText}`);
+        throw new Error(
+          `OpenAI API error: ${response.status} ${response.statusText}`,
+        );
       }
 
       const openAIResponse = await response.json();
@@ -190,19 +293,25 @@ export class OpenAICompatibleContentGenerator implements ContentGenerator {
   private async *_generateContentStream(
     request: GenerateContentParameters,
   ): AsyncGenerator<GenerateContentResponse> {
+    if (request.config?.tools && request.config.tools.length > 0) {
+      yield await this.generateContent(request);
+      return;
+    }
     const messages = this.convertToOpenAIMessages(request.contents);
-    
+
     // Add system instruction if provided
     if (request.config?.systemInstruction) {
       messages.unshift({
         role: 'system',
-        content: typeof request.config.systemInstruction === 'string' 
-          ? request.config.systemInstruction 
-          : (request.config.systemInstruction as any).text || '',
+        content:
+          typeof request.config.systemInstruction === 'string'
+            ? request.config.systemInstruction
+            : (request.config.systemInstruction as { text?: string }).text ||
+              '',
       });
     }
 
-    const openAIRequest = {
+    const openAIRequest: Record<string, unknown> = {
       model: this.config.model,
       messages,
       temperature: request.config?.temperature,
@@ -216,13 +325,17 @@ export class OpenAICompatibleContentGenerator implements ContentGenerator {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          ...(this.config.apiKey && { 'Authorization': `Bearer ${this.config.apiKey}` }),
+          ...(this.config.apiKey && {
+            Authorization: `Bearer ${this.config.apiKey}`,
+          }),
         },
         body: JSON.stringify(openAIRequest),
       });
 
       if (!response.ok) {
-        throw new Error(`OpenAI API error: ${response.status} ${response.statusText}`);
+        throw new Error(
+          `OpenAI API error: ${response.status} ${response.statusText}`,
+        );
       }
 
       const reader = response.body?.getReader();
@@ -239,7 +352,7 @@ export class OpenAICompatibleContentGenerator implements ContentGenerator {
 
         buffer += decoder.decode(value, { stream: true });
         const lines = buffer.split('\n');
-        
+
         // Keep the last line if it's incomplete
         buffer = lines.pop() || '';
 
@@ -247,25 +360,28 @@ export class OpenAICompatibleContentGenerator implements ContentGenerator {
           if (line.startsWith('data: ')) {
             const data = line.slice(6);
             if (data === '[DONE]') continue;
-            
+
             try {
               const chunk = JSON.parse(data);
               const delta = chunk.choices?.[0]?.delta;
-              
+
               if (delta?.content) {
                 const finishReason = chunk.choices?.[0]?.finish_reason;
-                const candidates = [{
-                  content: {
-                    role: 'model',
-                    parts: [{ text: delta.content }],
+                const candidates = [
+                  {
+                    content: {
+                      role: 'model',
+                      parts: [{ text: delta.content }],
+                    },
+                    index: 0,
+                    finishReason:
+                      finishReason === 'stop' ? FinishReason.STOP : undefined,
                   },
-                  index: 0,
-                  finishReason: finishReason === 'stop' ? FinishReason.STOP : undefined,
-                }];
-                
-                yield new OpenAIGenerateContentResponse(candidates) as any;
+                ];
+
+                yield new OpenAIGenerateContentResponse(candidates);
               }
-            } catch (e) {
+            } catch {
               // Ignore parse errors for individual chunks
             }
           }
@@ -277,7 +393,9 @@ export class OpenAICompatibleContentGenerator implements ContentGenerator {
     }
   }
 
-  async countTokens(request: CountTokensParameters): Promise<CountTokensResponse> {
+  async countTokens(
+    request: CountTokensParameters,
+  ): Promise<CountTokensResponse> {
     // Simple approximation - you might want to use a proper tokenizer
     let text = '';
     if (typeof request.contents === 'string') {
@@ -286,32 +404,34 @@ export class OpenAICompatibleContentGenerator implements ContentGenerator {
       text = request.contents
         .flatMap((content: Content) => content.parts || [])
         .filter((part: Part) => 'text' in part)
-        .map((part: Part) => (part as any).text)
+        .map((part: Part & { text?: string }) => part.text ?? '')
         .join(' ');
     } else {
       // Single Content object
       const content = request.contents as Content;
-      text = content.parts
-        ?.filter((part: Part) => 'text' in part)
-        .map((part: Part) => (part as any).text)
-        .join(' ') || '';
+      text =
+        content.parts
+          ?.filter((part: Part) => 'text' in part)
+          .map((part: Part & { text?: string }) => part.text ?? '')
+          .join(' ') || '';
     }
-    
+
     // Rough approximation: 1 token ≈ 4 characters
     const tokenCount = Math.ceil(text.length / 4);
-    
+
     return {
       totalTokens: tokenCount,
     };
   }
 
-  async embedContent(request: EmbedContentParameters): Promise<EmbedContentResponse> {
-    // For now, return a dummy embedding
-    // You would implement actual embedding API call here if needed
+  async embedContent(
+    request: EmbedContentParameters,
+  ): Promise<EmbedContentResponse> {
+    const count = Array.isArray(request.contents) ? request.contents.length : 1;
     return {
-      embeddings: [{
+      embeddings: Array.from({ length: count }, () => ({
         values: new Array(768).fill(0),
-      }],
+      })),
     };
   }
 }


### PR DESCRIPTION
## Summary
- support tool calls when using the OpenAI compatible generator
- return dummy embeddings for all input texts
- update createContentGenerator() and corresponding tests
- adjust HistoryItemDisplay test expectation
- handle malformed arguments in tool calls

## Testing
- `npm run lint:ci`
- `npm run test:ci`
- `npm run build`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68709be2b9bc832b982a9c51a2203981